### PR TITLE
Fix ESLint unused vars errors and update ignore patterns

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -9,7 +9,7 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     'plugin:react-hooks/recommended'
   ],
-  ignorePatterns: ['dist', '.eslintrc.cjs', 'vite.config.ts'],
+  ignorePatterns: ['dist', '.eslintrc.cjs', 'vite.config.ts', 'vitest.config.ts'],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 'latest',

--- a/frontend/src/utils/validations.test.ts
+++ b/frontend/src/utils/validations.test.ts
@@ -2,8 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { 
   cedearSchema, 
   tradeSchema, 
-  financialGoalSchema, 
-  settingsSchema,
+  financialGoalSchema,
   commissionConfigSchema,
   searchSchema 
 } from './validations'
@@ -103,7 +102,7 @@ describe('tradeSchema', () => {
   })
 
   it('acepta notas opcionales', () => {
-    const { notes, ...tradeWithoutNotes } = validTrade
+    const { notes: _notes, ...tradeWithoutNotes } = validTrade
     const result = tradeSchema.safeParse(tradeWithoutNotes)
     expect(result.success).toBe(true)
   })
@@ -142,7 +141,7 @@ describe('financialGoalSchema', () => {
   })
 
   it('acepta monto actual por defecto', () => {
-    const { currentAmount, ...goalWithoutCurrent } = validGoal
+    const { currentAmount: _currentAmount, ...goalWithoutCurrent } = validGoal
     const result = financialGoalSchema.safeParse(goalWithoutCurrent)
     expect(result.success).toBe(true)
     if (result.success) {
@@ -186,7 +185,7 @@ describe('commissionConfigSchema', () => {
   })
 
   it('acepta configuración sin montos opcionales', () => {
-    const { minAmount, maxAmount, ...configWithoutAmounts } = validConfig
+    const { minAmount: _minAmount, maxAmount: _maxAmount, ...configWithoutAmounts } = validConfig
     const result = commissionConfigSchema.safeParse(configWithoutAmounts)
     expect(result.success).toBe(true)
   })
@@ -210,7 +209,7 @@ describe('searchSchema', () => {
   })
 
   it('acepta búsqueda sin filtros', () => {
-    const { filters, ...searchWithoutFilters } = validSearch
+    const { filters: _filters, ...searchWithoutFilters } = validSearch
     const result = searchSchema.safeParse(searchWithoutFilters)
     expect(result.success).toBe(true)
   })


### PR DESCRIPTION
## Summary
- Fixed ESLint errors related to unused variables in validation tests by prefixing unused destructured variables with an underscore
- Updated ESLint configuration to ignore `vitest.config.ts` file

## Changes

### ESLint Configuration
- Added `vitest.config.ts` to the `ignorePatterns` array in `.eslintrc.cjs` to prevent linting errors on this config file

### Validation Tests
- Updated destructuring in `validations.test.ts` to rename unused variables with a leading underscore (`_`) to satisfy ESLint rules:
  - `notes` to `_notes`
  - `currentAmount` to `_currentAmount`
  - `minAmount` and `maxAmount` to `_minAmount` and `_maxAmount`
  - `filters` to `_filters`
- Removed unused imports `settingsSchema` from the test file

## Test plan
- Run ESLint to confirm no unused variable errors remain
- Run validation tests to ensure all tests pass successfully without modification to test logic

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/9cd1608c-f25a-4d2c-b834-364cba54a397