### PR TITLE
fix: add necessary permissions for GitHub Actions PR comments

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -5,6 +5,12 @@ on:
     branches: [ main, master, develop ]
     types: [ opened, synchronize, reopened ]
 
+# Permisos necesarios para que el workflow pueda acceder a la API de GitHub
+permissions:
+  contents: read          # Para leer el código del repositorio
+  pull-requests: read     # Para leer información de pull requests
+  issues: write          # Para crear y actualizar comentarios en PRs
+
 # Cancelar workflows anteriores si se hace un nuevo push
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Adds required permissions to the GitHub Actions workflow for PR validation
- Enables the workflow to read repository contents and pull request data
- Allows the workflow to create and update comments on pull requests

## Changes

### GitHub Actions Workflow
- Updated `.github/workflows/pr-validation.yml` to include `permissions` section:
  - `contents: read` to read repository code
  - `pull-requests: read` to access pull request information
  - `issues: write` to create and update PR comments

## Test plan
- [ ] Verify that the workflow can successfully read repository contents
- [ ] Confirm the workflow can access pull request details
- [ ] Check that the workflow can create and update comments on PRs
- [ ] Monitor workflow runs on PR events (opened, synchronize, reopened) to ensure no permission errors occur

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/f993846c-22c5-4280-b03a-03b00ac70348