### PR TITLE
fix: remove unused imports and variables in CommandPalette

### DIFF
--- a/frontend/src/components/ui/CommandPalette.tsx
+++ b/frontend/src/components/ui/CommandPalette.tsx
@@ -14,16 +14,11 @@ import {
   Sun,
   Monitor,
   Calculator,
-  BarChart3,
   Bell,
-  FileText,
-  Users,
-  Calendar,
   PieChart
 } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { useTheme } from '../../hooks/useTheme'
-import { useAppStore } from '../../store'
 import { cn } from '../../utils/cn'
 
 interface CommandPaletteProps {
@@ -47,7 +42,7 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({
 }) => {
   const [search, setSearch] = useState('')
   const navigate = useNavigate()
-  const { setTheme, theme } = useTheme()
+  const { setTheme } = useTheme()
 
   const commands: CommandItem[] = [
     // Navegación


### PR DESCRIPTION
## Summary
- Cleans up the `CommandPalette` component by removing unused imports and variables
- Improves code readability and reduces clutter

## Changes

### Frontend
- Removed unused icon imports: `BarChart3`, `FileText`, `Users`, `Calendar` from `lucide-react`
- Removed unused `useAppStore` import
- Removed unused `theme` variable from `useTheme` hook

## Test plan
- [x] Verify the CommandPalette component functions correctly without errors
- [x] Confirm no unused variables or imports remain in the file
- [x] Run existing tests to ensure no regressions

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/b98326ac-8094-4985-903e-fdd37a0e90bd