### PR TITLE
fix: rename unused variable in useGoalOptimizer hook

### DIFF
--- a/frontend/src/hooks/useGoalOptimizer.ts
+++ b/frontend/src/hooks/useGoalOptimizer.ts
@@ -140,7 +140,7 @@ export const useGoalOptimizer = (
   goalId: number,
   options: UseGoalOptimizerOptions = {}
 ): UseGoalOptimizerReturn => {
-  const { autoRefresh = false, refreshInterval = 300000, enableRealTimeUpdates = false } = options;
+  const { autoRefresh = false, refreshInterval = 300000, _enableRealTimeUpdates = false } = options;
 
   // Estado inicial
   const [state, setState] = useState<GoalOptimizerState>({


### PR DESCRIPTION
## Summary
- Fixes an unused variable warning in the `useGoalOptimizer` hook by renaming `enableRealTimeUpdates` to `_enableRealTimeUpdates` to indicate it is intentionally unused.

## Changes

### Code Fix
- Renamed `enableRealTimeUpdates` to `_enableRealTimeUpdates` in the destructuring of `options` in `useGoalOptimizer.ts` to avoid unused variable linting issues.

## Test plan
- Confirm no lint warnings related to unused variables in `useGoalOptimizer.ts`.
- Verify that the hook behavior remains unchanged after the variable rename.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/10a58a28-2415-44f7-b263-e4619dff87d3