### PR TITLE
fix: remove unused goalId prop from OpportunityMatcher component

### DIFF
--- a/frontend/src/pages/GoalOptimizer.tsx
+++ b/frontend/src/pages/GoalOptimizer.tsx
@@ -40,8 +40,7 @@ interface GoalOpportunityMatch {
   action_taken: boolean;
 }
 
-const OpportunityMatcher: React.FC<{ goalId: number; opportunities: GoalOpportunityMatch[] }> = ({ 
-  goalId, 
+const OpportunityMatcher: React.FC<{ opportunities: GoalOpportunityMatch[] }> = ({ 
   opportunities 
 }) => {
   const formatCurrency = (amount: number) => {
@@ -495,7 +494,6 @@ export const GoalOptimizer: React.FC = () => {
 
         <Tabs.Content value="opportunities">
           <OpportunityMatcher 
-            goalId={Number(goalId)}
             opportunities={summary?.opportunity_matches || []}
           />
         </Tabs.Content>


### PR DESCRIPTION
## Summary
- Removes the unused `goalId` prop from the `OpportunityMatcher` component in `GoalOptimizer.tsx`.
- Cleans up the component props and the corresponding usage in the `GoalOptimizer` page.

## Changes

### Frontend
- **GoalOptimizer.tsx**:
  - Removed `goalId` from the `OpportunityMatcher` component props.
  - Updated the component usage to no longer pass `goalId`.
  - Simplified the `OpportunityMatcher` component interface to only accept `opportunities`.

## Test plan
- [x] Verify that the `GoalOptimizer` page renders without errors.
- [x] Confirm that the opportunities list displays correctly.
- [x] Ensure no warnings or errors related to unused props in the console.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/190a4c13-5fcd-48bf-a6cf-190e88329436