### PR TITLE
Fix useHotkeys hook usage in useKeyboardShortcuts hook

### DIFF
--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -57,16 +57,27 @@ export const useKeyboardShortcuts = () => {
     { key: 'escape', description: 'Cerrar modal', category: 'UI', action: closeModal },
   ]
 
-  // Registrar shortcuts
-  shortcuts.forEach(({ key, action }) => {
-    useHotkeys(key, (e) => {
-      e.preventDefault()
-      action()
-    }, {
-      enableOnContentEditable: false,
-      enableOnFormTags: false,
-    })
-  })
+  // Registrar shortcuts individuales
+  const options = {
+    enableOnContentEditable: false,
+    enableOnFormTags: false,
+  }
+
+  // Navegación
+  useHotkeys('ctrl+1', (e) => { e.preventDefault(); goToDashboard() }, options)
+  useHotkeys('ctrl+2', (e) => { e.preventDefault(); goToWatchlist() }, options)
+  useHotkeys('ctrl+3', (e) => { e.preventDefault(); goToOpportunities() }, options)
+  useHotkeys('ctrl+4', (e) => { e.preventDefault(); goToPortfolio() }, options)
+  useHotkeys('ctrl+5', (e) => { e.preventDefault(); goToTrades() }, options)
+  useHotkeys('ctrl+6', (e) => { e.preventDefault(); goToGoals() }, options)
+  useHotkeys('ctrl+,', (e) => { e.preventDefault(); goToSettings() }, options)
+
+  // UI Controls
+  useHotkeys('ctrl+k', (e) => { e.preventDefault(); showCommandPalette() }, options)
+  useHotkeys('ctrl+/', (e) => { e.preventDefault(); showShortcutsHelp() }, options)
+  useHotkeys('ctrl+b', (e) => { e.preventDefault(); toggleSidebar() }, options)
+  useHotkeys('alt+t', (e) => { e.preventDefault(); toggleTheme() }, options)
+  useHotkeys('escape', (e) => { e.preventDefault(); closeModal() }, options)
 
   return {
     shortcuts,


### PR DESCRIPTION
## Summary
- Refactor `useKeyboardShortcuts` to register keyboard shortcuts individually instead of in a loop
- Fix issues with `useHotkeys` hook usage that caused errors
- Improve readability and maintainability of keyboard shortcut registrations

## Changes

### Keyboard Shortcuts Hook
- Removed loop-based registration of shortcuts
- Added explicit individual `useHotkeys` calls for each shortcut with consistent options
- Grouped shortcuts into navigation and UI controls for clarity
- Ensured `preventDefault` is called in each shortcut handler

## Test plan
- [x] Verify all keyboard shortcuts trigger their respective actions
- [x] Confirm no errors occur related to `useHotkeys` hook
- [x] Test navigation shortcuts (ctrl+1 to ctrl+6, ctrl+,)
- [x] Test UI control shortcuts (ctrl+k, ctrl+/, ctrl+b, alt+t, escape)

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/70da92fa-bf16-41b6-828d-7960723fb1c6