### PR TITLE
chore: specify node version for railway

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,5 @@
+[phases.setup]
+nixpkgsPackages = ["nodejs_20", "python3"]
+
+[start]
+cmd = "npm run start"


### PR DESCRIPTION
## Summary
- add nixpacks configuration to use Node 20 and Python for building

## Testing
- `npm test` *(fails: TypeError: this.db.run is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b7350322b48327a455664da9f87739