### PR TITLE
chore: specify node version for railway

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -53,5 +53,8 @@
     "tsx": "^4.6.2",
     "typescript": "^5.3.3",
     "vitest": "^1.0.4"
+  },
+  "engines": {
+    "node": "20.x"
   }
 }

--- a/claude-cli/package.json
+++ b/claude-cli/package.json
@@ -21,5 +21,8 @@
     "eslint": "^8.55.0",
     "typescript": "^5.3.3",
     "tsx": "^4.6.2"
+  },
+  "engines": {
+    "node": "20.x"
   }
 }

--- a/electron/package.json
+++ b/electron/package.json
@@ -26,6 +26,9 @@
     "typescript": "^5.3.3",
     "tsx": "^4.6.2"
   },
+  "engines": {
+    "node": "20.x"
+  },
   "build": {
     "appId": "com.cedears-manager.app",
     "productName": "CEDEARs Manager",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,5 +73,8 @@
     "typescript": "^5.2.2",
     "vite": "^5.0.8",
     "vitest": "^1.0.4"
+  },
+  "engines": {
+    "node": "20.x"
   }
 }

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,5 +1,5 @@
 [phases.setup]
-nixpkgsPackages = ["nodejs_20", "python3"]
+nixPkgs = ["nodejs_20", "python3"]
 
 [start]
 cmd = "cd backend && npm run start"


### PR DESCRIPTION
## Summary
- ensure Nixpacks installs Node 20 and Python for builds
- enforce Node 20 engine across all packages

## Testing
- `npm run quality:check` *(fails: ESLint errors and configuration issues)*
- `npm test` *(fails: TypeError: this.db.run is not a function)*
- `npm run build` *(fails: TypeScript compilation errors in frontend)*

------
https://chatgpt.com/codex/tasks/task_e_68b73b810cfc8327862a0e67401303b9