### PR TITLE
fix: import opportunity data type

### DIFF
--- a/backend/src/types/opportunity.ts
+++ b/backend/src/types/opportunity.ts
@@ -1,3 +1,6 @@
+import type { OpportunityData, OpportunityCreateInput, OpportunityFilters } from '../models/Opportunity.js'
+
+/* eslint-disable no-unused-vars */
 export interface OpportunitySignal {
   signal: 'BUY' | 'SELL' | 'HOLD'
   strength: number // 0-100
@@ -211,4 +214,4 @@ export interface OpportunityFilterRequest {
 }
 
 // Re-export del modelo principal
-export type { OpportunityData, OpportunityCreateInput, OpportunityFilters } from '../models/Opportunity.js'
+export type { OpportunityData, OpportunityCreateInput, OpportunityFilters }


### PR DESCRIPTION
## Summary
- import OpportunityData type so opportunity type definitions compile

## Testing
- `npm run lint:complexity`
- `npm run lint:duplicates` (fails: isFullwidthCodePoint is not a function)
- `npm test` (fails: 15 failed tests)
- `npm run build` (fails: frontend type errors)


------
https://chatgpt.com/codex/tasks/task_e_68b74f9d51e88327922ec3a5cc8f511d