### PR TITLE
feat: adjust tax report for trade model

### DIFF
--- a/backend/src/services/commission/CustodyCommissionService.ts
+++ b/backend/src/services/commission/CustodyCommissionService.ts
@@ -1,6 +1,15 @@
 import { logger } from '../../utils/logger.js'
 import type { CommissionConfig, CustodyCalculation } from '../../types/commission.js'
 
+export interface CustodyFeeRecord {
+  month: string
+  portfolioValue: number
+  feePercentage: number
+  feeAmount: number
+  ivaAmount: number
+  totalCharged: number
+}
+
 /**
  * Servicio especializado en cálculos de comisiones de custodia
  */
@@ -44,6 +53,14 @@ export class CustodyCommissionService {
       logger.error('Error calculating custody fee:', error)
       throw new Error(`Failed to calculate custody fee: ${error instanceof Error ? error.message : String(error)}`)
     }
+  }
+
+  /**
+   * Obtiene registros históricos de custodia
+   */
+  async getHistoricalFees(_opts: { startDate: string; endDate: string }): Promise<CustodyFeeRecord[]> {
+    logger.warn('getHistoricalFees not implemented, returning empty array')
+    return []
   }
 
   /**


### PR DESCRIPTION
## Summary
- align tax report with snake_case trade model fields
- add placeholder custody fee history method for tax reports

## Testing
- `npm run lint:complexity` (fails: ESLint configuration issues)
- `npm run lint:duplicates` (fails: TypeError in cli-table3)
- `npm test` (fails: GoalTrackerService this.db.run not a function)
- `npm run build` (fails: frontend type errors)
- `npm run build` (backend) (fails: CostReportService and ExportService type errors)


------
https://chatgpt.com/codex/tasks/task_e_68b7537190a88327b776217e4a81741c