### PR TITLE
fix: use named logger import

### DIFF
--- a/backend/src/controllers/BenchmarkController.ts
+++ b/backend/src/controllers/BenchmarkController.ts
@@ -3,7 +3,9 @@ import { z } from 'zod'
 import { benchmarkIndicesModel } from '../models/BenchmarkIndices.js'
 import { benchmarkDataService } from '../services/BenchmarkDataService.js'
 import { performanceAnalysisService } from '../services/PerformanceAnalysisService.js'
-import logger from '../utils/logger.js'
+import { createLogger } from '../utils/logger.js'
+
+const logger = createLogger('benchmark-controller')
 
 // Validation schemas
 const comparePerformanceSchema = z.object({


### PR DESCRIPTION
## Summary
- import logger via createLogger in BenchmarkController

## Testing
- `npm run lint:complexity` *(fails: Parsing error in vitest.config.ts, unused vars, max-lines-per-function)*
- `npm run lint:duplicates` *(fails: TypeError in cli-table3 during report generation)*
- `npm test` *(fails: GoalOptimizerService tests, TypeError: this.db.run is not a function)*
- `npm run backend:build` *(fails: multiple TS2339/TS2551 errors in CostReportService)*

------
https://chatgpt.com/codex/tasks/task_e_68b7636c05388327ab7585e624b03c6a