### PR TITLE
chore: continue quality report despite lint errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint:complexity": "npm run frontend:lint && npm run backend:lint",
     "lint:duplicates": "jscpd --config .jscpdrc.json",
     "quality:check": "npm run lint:complexity && npm run lint:duplicates",
-    "quality:report": "npm run quality:setup && npm run quality:check && npm run quality:dashboard",
+    "quality:report": "npm run quality:setup && (npm run lint:complexity || true) && (npm run lint:duplicates || true) && npm run quality:dashboard",
     "quality:setup": "rimraf quality-reports && mkdir quality-reports && mkdir quality-reports\\eslint && mkdir quality-reports\\duplicates",
     "quality:dashboard": "node scripts/create-quality-dashboard.js",
     "quality:html-reports": "npm run quality:eslint-html && npm run lint:duplicates",


### PR DESCRIPTION
## Summary
- prevent lint and jscpd failures from aborting quality report generation

## Testing
- `npm run lint:complexity` *(fails: ESLint errors)*
- `npm run lint:duplicates` *(fails: isFullwidthCodePoint is not a function)*
- `npm test` *(fails: TypeError: this.db.run is not a function)*
- `npm run build` *(fails: TypeScript compilation errors in frontend)*
- `npm run quality:report` *(dashboard generated despite lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b8425a200883278c274fe4e2155604