### PR TITLE
refactor: use named Instrument import

### DIFF
--- a/backend/src/jobs/ESGVeganEvaluationJob.ts
+++ b/backend/src/jobs/ESGVeganEvaluationJob.ts
@@ -1,7 +1,7 @@
 import * as cron from 'node-cron'
 import ESGAnalysisService from '../services/ESGAnalysisService.js'
 import VeganAnalysisService from '../services/VeganAnalysisService.js'
-import InstrumentModel from '../models/Instrument.js'
+import { Instrument as InstrumentModel } from '../models/Instrument.js'
 import ESGEvaluationModel from '../models/ESGEvaluation.js'
 import VeganEvaluationModel from '../models/VeganEvaluation.js'
 import { createLogger } from '../utils/logger.js'

--- a/backend/src/services/ESGAnalysisService.ts
+++ b/backend/src/services/ESGAnalysisService.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import * as cheerio from 'cheerio'
 import ESGEvaluationModel, { ESGEvaluation, ESGScoreBreakdown } from '../models/ESGEvaluation.js'
-import InstrumentModel from '../models/Instrument.js'
+import { Instrument as InstrumentModel } from '../models/Instrument.js'
 import { ClaudeContextualService } from './ClaudeContextualService.js'
 import { NewsAnalysisService } from './NewsAnalysisService.js'
 import { createLogger } from '../utils/logger.js'

--- a/backend/src/services/VeganAnalysisService.ts
+++ b/backend/src/services/VeganAnalysisService.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import * as cheerio from 'cheerio'
 import VeganEvaluationModel, { VeganEvaluation, VeganCriteria } from '../models/VeganEvaluation.js'
-import InstrumentModel from '../models/Instrument.js'
+import { Instrument as InstrumentModel } from '../models/Instrument.js'
 import { ClaudeContextualService } from './ClaudeContextualService.js'
 import { NewsAnalysisService } from './NewsAnalysisService.js'
 import { createLogger } from '../utils/logger.js'


### PR DESCRIPTION
## Summary
- fix Instrument model import by using named export in ESG and Vegan services

## Testing
- `npm run lint:complexity` *(fails: max-lines-per-function and parsing errors)*
- `npm run lint:duplicates` *(fails: TypeError in cli-table3)*
- `npm test` *(fails: GoalTrackerService uses db.run)*
- `npm run backend:build` *(fails: numerous TS errors in CostReportService)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b3295f608327a5fbccb58721d6d0