### PR TITLE
fix: ensure getNextCustodyDate returns string

### DIFF
--- a/backend/src/controllers/CustodyController.ts
+++ b/backend/src/controllers/CustodyController.ts
@@ -466,7 +466,8 @@ export class CustodyController {
     nextMonth.setMonth(nextMonth.getMonth() + 1)
     nextMonth.setDate(1)
     nextMonth.setHours(9, 0, 0, 0)
-    return nextMonth.toISOString().split('T')[0]
+    const [datePart] = nextMonth.toISOString().split('T')
+    return datePart ?? ''
   }
 
   private generateBasicRecommendations(


### PR DESCRIPTION
## Summary
- prevent undefined return in CustodyController#getNextCustodyDate

## Testing
- `npm run lint:complexity` *(fails: ESLint errors in backend)*
- `npm run lint:duplicates` *(fails: TypeError isFullwidthCodePoint not a function)*
- `npm test` *(fails: GoalOptimizerService suite failing)*
- `npm run backend:build` *(fails: TS errors in CostReportService)*

------
https://chatgpt.com/codex/tasks/task_e_68b9df0d41e083279e5992a07748c478