### PR TITLE
fix: correct imports in benchmark indices model

### DIFF
--- a/backend/src/models/BenchmarkIndices.ts
+++ b/backend/src/models/BenchmarkIndices.ts
@@ -1,5 +1,5 @@
-import { DatabaseConnection } from '../database/connection.js'
-import logger from '../utils/logger.js'
+import DatabaseConnection from '../database/connection.js'
+import { logger } from '../utils/logger.js'
 
 export interface BenchmarkIndex {
   id?: number


### PR DESCRIPTION
## Summary
- fix imports in `BenchmarkIndices` model to use default `DatabaseConnection` and named `logger`

## Testing
- `npm run lint:complexity`
- `npm run lint:duplicates`
- `npm test` (fails: this.db.run is not a function)
- `npm run backend:build` (fails: 553 TypeScript errors)


------
https://chatgpt.com/codex/tasks/task_e_68bb2ec9d558832781651107a8e805f7