### PR TITLE
fix: remove unused React imports causing TS6133 errors

### DIFF
--- a/frontend/src/components/TechnicalIndicators/SignalAlerts.tsx
+++ b/frontend/src/components/TechnicalIndicators/SignalAlerts.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { useActiveSignals, useForceJobRun } from '../../hooks/useTechnicalIndicators'
 import { technicalIndicatorService } from '../../services/technicalIndicatorService'
 import { Card } from '../ui/Card'

--- a/frontend/src/components/break-even/BreakEvenCalculator.tsx
+++ b/frontend/src/components/break-even/BreakEvenCalculator.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import { useState, useEffect } from 'react'
 import { Calculator, AlertCircle, TrendingUp, TrendingDown, DollarSign } from 'lucide-react'
 import { useBreakEvenSimulationMutation } from '../../hooks/useBreakEven'
 

--- a/frontend/src/components/goals/GoalAlerts.tsx
+++ b/frontend/src/components/goals/GoalAlerts.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Card } from '../ui/Card';
 import { Button } from '../ui/Button';
 import { Badge } from '../ui/Badge';


### PR DESCRIPTION
## Summary
- drop unused React default imports in several frontend components to satisfy TS6133

## Testing
- `npm run lint:complexity`
- `npm run lint:duplicates`
- `npm test` *(fails: this.db.run is not a function)*
- `npm run build` *(fails: tsc found existing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3988f0048327b95ca5001263bfa7