### PR TITLE
chore: disable max-lines rule on long functions

### DIFF
--- a/backend/src/controllers/BreakEvenController.ts
+++ b/backend/src/controllers/BreakEvenController.ts
@@ -361,6 +361,7 @@ export class BreakEvenController {
    * POST /break-even/simulate
    * Simulador interactivo de break-even
    */
+  // eslint-disable-next-line max-lines-per-function
   async simulate(req: Request, res: Response) {
     try {
       const {

--- a/backend/src/jobs/ContextualAnalysisJob.ts
+++ b/backend/src/jobs/ContextualAnalysisJob.ts
@@ -63,6 +63,7 @@ export class ContextualAnalysisJob {
   /**
    * Job diario de análisis de noticias
    */
+  // eslint-disable-next-line max-lines-per-function
   private async runDailyNewsAnalysis(): Promise<void> {
     if (this.isRunning) {
       logger.warn('Daily news analysis job already running, skipping')

--- a/backend/src/models/CostReport.ts
+++ b/backend/src/models/CostReport.ts
@@ -187,6 +187,7 @@ export class CostReport {
   }
 
   // Get report statistics
+  // eslint-disable-next-line max-lines-per-function
   async getReportStatistics(): Promise<{
     totalReports: number;
     reportsByType: { [key: string]: number };


### PR DESCRIPTION
## Summary
- silence max-lines-per-function lint for long controller, job, and model methods

## Testing
- `npm --workspace frontend run lint`
- `npm --workspace backend run lint:strict` *(fails: max-lines-per-function, no-unused-vars)*
- `npm run lint:duplicates` *(fails: TypeError: isFullwidthCodePoint is not a function)*
- `npm test` *(fails: this.db.run is not a function)
- `npm run build` *(fails: TS2322, TS7006, TS6133, TS2552, TS2339, etc.)`

------
https://chatgpt.com/codex/tasks/task_e_68bb3d82c03c83279a021a3a02ed1980