### PR TITLE
fix: adjust select handlers and badge variants

### DIFF
--- a/frontend/src/pages/Custody.tsx
+++ b/frontend/src/pages/Custody.tsx
@@ -66,8 +66,8 @@ export const CustodyPage: React.FC = () => {
           </p>
         </div>
         <div className="flex items-center space-x-3">
-          <Badge 
-            variant={isExempt ? 'success' : 'warning'}
+          <Badge
+            variant={isExempt ? 'success' : 'destructive'}
             className="text-sm px-3 py-1"
           >
             {isExempt ? '✅ Exento' : '💰 Con Custodia'}

--- a/frontend/src/pages/Goals.tsx
+++ b/frontend/src/pages/Goals.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '../components/ui/Button';
 import { Card } from '../components/ui/Card';
@@ -136,7 +136,7 @@ export default function Goals() {
                 {/* Botón de optimizador */}
                 <div className="mt-3 pt-3 border-t border-gray-200">
                   <Button
-                    size="small"
+                    size="sm"
                     variant="outline"
                     className="w-full text-xs"
                     onClick={(e) => {
@@ -248,8 +248,8 @@ export default function Goals() {
           )}
 
           {activeTab === 'simulator' && (
-            <ContributionSimulator
-              goalId={selectedGoalId}
+              <ContributionSimulator
+              goalId={selectedGoalId ?? 0}
               currency={selectedGoal.currency}
               currentCapital={dashboard?.latestProgress?.current_capital || 0}
               onSimulate={simulate}

--- a/frontend/src/pages/Opportunities.tsx
+++ b/frontend/src/pages/Opportunities.tsx
@@ -242,7 +242,7 @@ export default function Opportunities() {
           
           <Select
             value={String(filters.minScore)}
-            onValueChange={(value) => handleFilterChange('minScore', Number(value))}
+            onChange={(e) => handleFilterChange('minScore', Number(e.target.value))}
           >
             <option value="50">Score mín: 50</option>
             <option value="60">Score mín: 60</option>
@@ -252,7 +252,7 @@ export default function Opportunities() {
           
           <Select
             value={filters.opportunityType}
-            onValueChange={(value) => handleFilterChange('opportunityType', value)}
+            onChange={(e) => handleFilterChange('opportunityType', e.target.value)}
           >
             <option value="ALL">Todos los tipos</option>
             <option value="BUY">Compra</option>
@@ -261,7 +261,7 @@ export default function Opportunities() {
           
           <Select
             value={filters.isESG === null ? 'ALL' : String(filters.isESG)}
-            onValueChange={(value) => handleFilterChange('isESG', value === 'ALL' ? null : value === 'true')}
+            onChange={(e) => handleFilterChange('isESG', e.target.value === 'ALL' ? null : e.target.value === 'true')}
           >
             <option value="ALL">Cualquier ESG</option>
             <option value="true">Solo ESG</option>
@@ -270,7 +270,7 @@ export default function Opportunities() {
           
           <Select
             value={filters.isVegan === null ? 'ALL' : String(filters.isVegan)}
-            onValueChange={(value) => handleFilterChange('isVegan', value === 'ALL' ? null : value === 'true')}
+            onChange={(e) => handleFilterChange('isVegan', e.target.value === 'ALL' ? null : e.target.value === 'true')}
           >
             <option value="ALL">Cualquier Vegan</option>
             <option value="true">Solo Vegan</option>


### PR DESCRIPTION
## Summary
- fix incorrect badge variant in custody page
- use valid button size and goal id fallback in goals page
- replace onValueChange with onChange in opportunities filters

## Testing
- `npm run lint` *(fails: ESLint configuration issues)*
- `npm run lint:complexity` *(fails: ESLint configuration issues)*
- `npm run lint:duplicates`
- `npm test` *(fails: GoalTrackerService DB errors)*
- `npm run build` *(fails: remaining TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bf020c6bc083279ecb7e30ac1d1e5b