### PR TITLE
chore: suppress max-lines-per-function in backend helpers

### DIFF
--- a/backend/src/controllers/ESGVeganController.ts
+++ b/backend/src/controllers/ESGVeganController.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines-per-function */
 import { Request, Response } from 'express'
 import { z } from 'zod'
 import ESGAnalysisService from '../services/ESGAnalysisService.js'

--- a/backend/src/jobs/quoteUpdateJob.ts
+++ b/backend/src/jobs/quoteUpdateJob.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines-per-function */
 import cron from 'node-cron'
 import { quoteService } from '../services/QuoteService.js'
 import { createLogger } from '../utils/logger.js'

--- a/backend/src/utils/uvaHelpers.ts
+++ b/backend/src/utils/uvaHelpers.ts
@@ -1,7 +1,7 @@
+/* eslint-disable max-lines-per-function */
 import { UVAService } from '../services/UVAService.js'
-import { UVAData, UVAInflationAdjustment } from '../models/UVA.js'
 import { createLogger } from './logger.js'
-import { format, parseISO, isValid, differenceInDays, startOfMonth, endOfMonth, startOfYear, endOfYear } from 'date-fns'
+import { format, parseISO, isValid, differenceInDays, startOfMonth, startOfYear } from 'date-fns'
 
 const logger = createLogger('UVAHelpers')
 


### PR DESCRIPTION
## Summary
- disable max-lines-per-function in select backend helpers and jobs
- remove unused imports in uvaHelpers

## Testing
- `npm run lint:complexity` *(fails: no-unused-vars etc.)*
- `npm run lint:duplicates` *(fails: TypeError: isFullwidthCodePoint is not a function)*
- `npm test` *(fails: GoalTrackerService this.db.run is not a function)*
- `npm run build` *(fails: TS errors in frontend)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1b1a5b548327be499f2cd0c42904