### PR TITLE
refactor: fix type errors in ui components

### DIFF
--- a/frontend/src/components/TechnicalIndicators/TechnicalIndicatorsList.tsx
+++ b/frontend/src/components/TechnicalIndicators/TechnicalIndicatorsList.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import { useLatestIndicators, useCalculateIndicators } from '../../hooks/useTechnicalIndicators'
 import { technicalIndicatorService } from '../../services/technicalIndicatorService'
 import { Card } from '../ui/Card'
 import { Button } from '../ui/Button'
 import { Badge } from '../ui/Badge'
 import { RefreshCw, TrendingUp, TrendingDown, Minus, Activity, Target, BarChart3 } from 'lucide-react'
+import type { TechnicalIndicator } from '../../../../shared/src/types'
 
 interface TechnicalIndicatorsListProps {
   symbol: string
@@ -12,13 +13,19 @@ interface TechnicalIndicatorsListProps {
   compact?: boolean
 }
 
-export function TechnicalIndicatorsList({ 
-  symbol, 
-  showCalculateButton = true, 
-  compact = false 
+interface IndicatorWithExtras extends TechnicalIndicator {
+  period?: number
+  metadata?: Record<string, unknown>
+}
+
+export function TechnicalIndicatorsList({
+  symbol,
+  showCalculateButton = true,
+  compact = false
 }: TechnicalIndicatorsListProps) {
   const [calculating, setCalculating] = useState(false)
-  const { data: indicators, isLoading, error, refetch } = useLatestIndicators(symbol)
+  const { data, isLoading, error, refetch } = useLatestIndicators(symbol)
+  const indicators: IndicatorWithExtras[] = (data || []) as IndicatorWithExtras[]
   const calculateMutation = useCalculateIndicators()
 
   const handleCalculate = async () => {

--- a/frontend/src/components/ui/PageTransition.tsx
+++ b/frontend/src/components/ui/PageTransition.tsx
@@ -1,9 +1,9 @@
-import React from 'react'
-import { motion, AnimatePresence } from 'framer-motion'
+import { AnimatePresence, motion, type Transition } from 'framer-motion'
 import { useLocation } from 'react-router-dom'
+import type { FC, ReactNode } from 'react'
 
 interface PageTransitionProps {
-  children: React.ReactNode
+  children: ReactNode
   className?: string
 }
 
@@ -25,15 +25,15 @@ const pageVariants = {
   }
 }
 
-const pageTransition = {
+const pageTransition: Transition = {
   type: 'tween',
   ease: 'anticipate',
   duration: 0.4
 }
 
-export const PageTransition: React.FC<PageTransitionProps> = ({ 
-  children, 
-  className 
+export const PageTransition: FC<PageTransitionProps> = ({
+  children,
+  className
 }) => {
   const location = useLocation()
   
@@ -55,8 +55,8 @@ export const PageTransition: React.FC<PageTransitionProps> = ({
 }
 
 // Transición específica para modales
-export const ModalTransition: React.FC<{
-  children: React.ReactNode
+export const ModalTransition: FC<{
+  children: ReactNode
   isOpen: boolean
 }> = ({ children, isOpen }) => {
   return (
@@ -88,8 +88,8 @@ export const ModalTransition: React.FC<{
 }
 
 // Transición para sidebar
-export const SidebarTransition: React.FC<{
-  children: React.ReactNode
+export const SidebarTransition: FC<{
+  children: ReactNode
   isCollapsed: boolean
 }> = ({ children, isCollapsed }) => {
   return (

--- a/frontend/src/components/ui/ThemeToggle.tsx
+++ b/frontend/src/components/ui/ThemeToggle.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { Sun, Moon, Monitor } from 'lucide-react'
 import { useTheme } from '../../hooks/useTheme'
 import { Button } from './Button'


### PR DESCRIPTION
## Summary
- remove unused React import from ThemeToggle
- type PageTransition and transitions to satisfy framer-motion
- extend indicator typings in TechnicalIndicatorsList

## Testing
- `npx eslint frontend/src/components/ui/ThemeToggle.tsx frontend/src/components/ui/PageTransition.tsx frontend/src/components/TechnicalIndicators/TechnicalIndicatorsList.tsx`
- `npm test`
- `npm run lint:duplicates`
- `npm run build` *(fails: Cannot find module './apiClient' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c02a0776548327aecaa423ea9d9bd2