### PR TITLE
fix: cleanup goal optimizer components

### DIFF
--- a/frontend/src/components/goals/optimizer/ContributionOptimizer.tsx
+++ b/frontend/src/components/goals/optimizer/ContributionOptimizer.tsx
@@ -49,11 +49,6 @@ export const ContributionOptimizer: React.FC<ContributionOptimizerProps> = ({
   const [customAmount, setCustomAmount] = useState(currentContribution);
   const [showCustomPlan, setShowCustomPlan] = useState(false);
   const [isCalculating, setIsCalculating] = useState(false);
-
-  useEffect(() => {
-    loadContributionPlans();
-  }, [goalId, loadContributionPlans]);
-
   const loadContributionPlans = useCallback(async () => {
     setIsLoading(true);
     
@@ -121,6 +116,10 @@ export const ContributionOptimizer: React.FC<ContributionOptimizerProps> = ({
       setIsLoading(false);
     }
   }, [goalId, currentContribution, requiredContribution]);
+
+  useEffect(() => {
+    loadContributionPlans();
+  }, [goalId, loadContributionPlans]);
 
   const calculateCustomPlan = async () => {
     if (customAmount <= currentContribution) {
@@ -209,7 +208,7 @@ export const ContributionOptimizer: React.FC<ContributionOptimizerProps> = ({
     return (
       <Card className="p-6">
         <div className="flex items-center justify-center space-x-2">
-          <LoadingSpinner size="small" />
+          <LoadingSpinner size="sm" />
           <span>Cargando planes de contribución...</span>
         </div>
       </Card>
@@ -278,7 +277,7 @@ export const ContributionOptimizer: React.FC<ContributionOptimizerProps> = ({
                 disabled={isCalculating || customAmount <= currentContribution}
                 className="flex items-center space-x-2"
               >
-                {isCalculating && <LoadingSpinner size="small" />}
+                {isCalculating && <LoadingSpinner size="sm" />}
                 <span>{isCalculating ? 'Calculando...' : 'Calcular'}</span>
               </Button>
             </div>
@@ -308,7 +307,7 @@ export const ContributionOptimizer: React.FC<ContributionOptimizerProps> = ({
                 <Button
                   onClick={() => activatePlan(selectedPlan)}
                   className="mt-3"
-                  size="small"
+                  size="sm"
                 >
                   Activar Plan Personalizado
                 </Button>
@@ -403,14 +402,14 @@ export const ContributionOptimizer: React.FC<ContributionOptimizerProps> = ({
                   {!plan.is_active ? (
                     <Button
                       onClick={() => activatePlan(plan)}
-                      size="small"
+                      size="sm"
                     >
                       Activar Plan
                     </Button>
                   ) : (
                     <Button
                       variant="outline"
-                      size="small"
+                      size="sm"
                       disabled
                     >
                       Plan Activo

--- a/frontend/src/components/goals/optimizer/GapAnalysisPanel.tsx
+++ b/frontend/src/components/goals/optimizer/GapAnalysisPanel.tsx
@@ -48,10 +48,6 @@ export const GapAnalysisPanel: React.FC<GapAnalysisPanelProps> = ({
   const [error, setError] = useState<string | null>(null);
   const [isAnalyzing, setIsAnalyzing] = useState(false);
 
-  // Cargar análisis existente al montar el componente
-  useEffect(() => {
-    loadExistingAnalysis();
-  }, [goalId, loadExistingAnalysis]);
   const loadExistingAnalysis = useCallback(async () => {
     setIsLoading(true);
     setError(null);
@@ -95,6 +91,11 @@ export const GapAnalysisPanel: React.FC<GapAnalysisPanelProps> = ({
       setIsLoading(false);
     }
   }, [goalId]);
+
+  // Cargar análisis existente al montar el componente
+  useEffect(() => {
+    loadExistingAnalysis();
+  }, [goalId, loadExistingAnalysis]);
 
   const performNewAnalysis = async () => {
     setIsAnalyzing(true);
@@ -160,7 +161,7 @@ export const GapAnalysisPanel: React.FC<GapAnalysisPanelProps> = ({
     return (
       <Card className="p-6">
         <div className="flex items-center justify-center space-x-2">
-          <LoadingSpinner size="small" />
+          <LoadingSpinner size="sm" />
           <span>Cargando análisis de gap...</span>
         </div>
       </Card>
@@ -170,10 +171,8 @@ export const GapAnalysisPanel: React.FC<GapAnalysisPanelProps> = ({
   if (error) {
     return (
       <Card className="p-6">
-        <Alert type="error" title="Error">
-          {error}
-        </Alert>
-        <Button 
+        <Alert variant="destructive">{error}</Alert>
+        <Button
           onClick={performNewAnalysis}
           className="mt-4"
         >
@@ -201,7 +200,7 @@ export const GapAnalysisPanel: React.FC<GapAnalysisPanelProps> = ({
           disabled={isAnalyzing}
           className="flex items-center space-x-2"
         >
-          {isAnalyzing && <LoadingSpinner size="small" />}
+          {isAnalyzing && <LoadingSpinner size="sm" />}
           <span>{isAnalyzing ? 'Analizando...' : 'Actualizar Análisis'}</span>
         </Button>
       </div>

--- a/frontend/src/components/goals/optimizer/MilestoneTracker.tsx
+++ b/frontend/src/components/goals/optimizer/MilestoneTracker.tsx
@@ -32,23 +32,17 @@ interface MilestoneTrackerProps {
   goalId: number;
   currentCapital: number;
   targetCapital: number;
-  onMilestoneUpdate?: (milestone: Milestone) => void;
 }
 
 export const MilestoneTracker: React.FC<MilestoneTrackerProps> = ({
   goalId,
   currentCapital,
-  targetCapital,
-  onMilestoneUpdate
+  targetCapital
 }) => {
   const [milestones, setMilestones] = useState<Milestone[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
   const [selectedMilestone, setSelectedMilestone] = useState<Milestone | null>(null);
-
-  useEffect(() => {
-    loadMilestones();
-  }, [goalId, loadMilestones]);
   const loadMilestones = useCallback(async () => {
     setIsLoading(true);
     
@@ -165,6 +159,10 @@ export const MilestoneTracker: React.FC<MilestoneTrackerProps> = ({
     }
   }, [goalId, currentCapital, targetCapital]);
 
+  useEffect(() => {
+    loadMilestones();
+  }, [goalId, loadMilestones]);
+
   const generateNewMilestones = async () => {
     setIsGenerating(true);
     
@@ -176,32 +174,6 @@ export const MilestoneTracker: React.FC<MilestoneTrackerProps> = ({
       console.error('Error generating milestones:', error);
     } finally {
       setIsGenerating(false);
-    }
-  };
-
-  const _updateMilestoneProgress = async (milestone: Milestone, progress: number) => {
-    try {
-      // En implementación real: llamada a API
-      // await fetch(`/api/goal-optimizer/milestones/${milestone.id}/progress`, {
-      //   method: 'PUT',
-      //   headers: { 'Content-Type': 'application/json' },
-      //   body: JSON.stringify({ current_progress: progress })
-      // });
-      
-      const updatedMilestone = {
-        ...milestone,
-        current_progress: progress,
-        progress_percentage: Math.min(100, (progress / (milestone.target_amount || 100)) * 100),
-        is_achieved: progress >= (milestone.target_amount || 100)
-      };
-      
-      setMilestones(prev => prev.map(m => m.id === milestone.id ? updatedMilestone : m));
-      
-      if (onMilestoneUpdate) {
-        onMilestoneUpdate(updatedMilestone);
-      }
-    } catch (error) {
-      console.error('Error updating milestone:', error);
     }
   };
 
@@ -257,7 +229,7 @@ export const MilestoneTracker: React.FC<MilestoneTrackerProps> = ({
     return (
       <Card className="p-6">
         <div className="flex items-center justify-center space-x-2">
-          <LoadingSpinner size="small" />
+          <LoadingSpinner size="sm" />
           <span>Cargando hitos intermedios...</span>
         </div>
       </Card>
@@ -286,7 +258,7 @@ export const MilestoneTracker: React.FC<MilestoneTrackerProps> = ({
             variant="outline"
             className="flex items-center space-x-2"
           >
-            {isGenerating && <LoadingSpinner size="small" />}
+            {isGenerating && <LoadingSpinner size="sm" />}
             <span>{isGenerating ? 'Generando...' : 'Regenerar Hitos'}</span>
           </Button>
         </div>


### PR DESCRIPTION
## Summary
- refactor goal optimizer components to resolve type errors
- adjust spinner/button sizes to use design tokens
- simplify milestone tracker props and remove unused logic

## Testing
- `npm test` (fails: this.uvaService.getLatestUVA is not a function)
- `npm run lint:complexity` (fails: ESLint parsing errors in backend)
- `npm run lint:duplicates` (fails: TypeError: isFullwidthCodePoint is not a function)
- `npm run build` (fails: frontend type errors remain)


------
https://chatgpt.com/codex/tasks/task_e_68c030bfb9c48327ac360211d50948c4