### PR TITLE
fix: resolve selected compilation errors in frontend

### DIFF
--- a/frontend/src/pages/SectorBalance.tsx
+++ b/frontend/src/pages/SectorBalance.tsx
@@ -142,9 +142,9 @@ const SectorBalance: React.FC = () => {
       )}
 
       {activeTab === 'analytics' && (
-        <AnalyticsTab 
-          analyticsData={analyticsData}
-          isLoading={analyticsData.isLoading}
+        <AnalyticsTab
+          analyticsData={_analyticsData}
+          isLoading={_analyticsData.isLoading}
         />
       )}
 

--- a/frontend/src/pages/Trades.tsx
+++ b/frontend/src/pages/Trades.tsx
@@ -8,7 +8,7 @@ import { Alert } from '../components/ui/Alert';
 import { LoadingSpinner } from '../components/ui/LoadingSpinner';
 import { useInstruments } from '../hooks/useInstruments';
 import { useCommissions } from '../hooks/useCommissions';
-import { TrendingUp, TrendingDown, Calculator, AlertTriangle, History, DollarSign } from 'lucide-react';
+import { TrendingUp, TrendingDown, Calculator, History, DollarSign } from 'lucide-react';
 import { apiService } from '../services/api';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 
@@ -283,8 +283,7 @@ export function Trades() {
 
               <div className="space-y-4">
                 <Alert
-                  variant={commissionPreview.totalCommission / totalAmount > 0.01 ? 'warning' : 'info'}
-                  icon={AlertTriangle}
+                  variant={commissionPreview.totalCommission / totalAmount > 0.01 ? 'warning' : 'default'}
                 >
                   {commissionPreview.totalCommission / totalAmount > 0.01
                     ? 'Las comisiones representan más del 1% del monto total'
@@ -305,7 +304,6 @@ export function Trades() {
                       return (
                         <Alert
                           variant="destructive"
-                          icon={AlertTriangle}
                         >
                           <div>
                             <p className="font-semibold">⚠️ Alerta: Alto impacto de comisiones</p>

--- a/frontend/src/services/opportunityService.ts
+++ b/frontend/src/services/opportunityService.ts
@@ -1,4 +1,4 @@
-import { api } from '../utils/api'
+import api from '../utils/api'
 import type { 
   OpportunityData, 
   OpportunityStats, 


### PR DESCRIPTION
## Summary
- fix analytics data reference in SectorBalance tab
- clean Trades alerts props and imports
- correct opportunity service API import

## Testing
- `npm run lint:complexity` *(fails: Method 'generateMockPDF' has too many lines...)*
- `npm run lint:duplicates` *(fails: TypeError isFullwidthCodePoint is not a function)*
- `npm test` *(fails: goal-optimizer.test.ts:490:25)*

------
https://chatgpt.com/codex/tasks/task_e_68c0461430288327abaada2a04658f00