### PR TITLE
fix: address backend lint warnings

### DIFF
--- a/backend/src/controllers/UVAController.ts
+++ b/backend/src/controllers/UVAController.ts
@@ -3,7 +3,7 @@ import { UVAService } from '../services/UVAService.js'
 import { uvaUpdateJob } from '../jobs/uvaUpdateJob.js'
 import { createLogger } from '../utils/logger.js'
 import { z } from 'zod'
-import { format, isValid, parseISO } from 'date-fns'
+import { isValid, parseISO } from 'date-fns'
 
 const logger = createLogger('UVAController')
 
@@ -13,17 +13,6 @@ const dateParamSchema = z.object({
     const parsed = parseISO(date)
     return isValid(parsed)
   }, 'Invalid date format. Use YYYY-MM-DD')
-})
-
-const dateRangeSchema = z.object({
-  fromDate: z.string().refine((date) => {
-    const parsed = parseISO(date)
-    return isValid(parsed)
-  }, 'Invalid fromDate format. Use YYYY-MM-DD'),
-  toDate: z.string().refine((date) => {
-    const parsed = parseISO(date)
-    return isValid(parsed)
-  }, 'Invalid toDate format. Use YYYY-MM-DD')
 })
 
 const searchUVASchema = z.object({

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -12,7 +12,8 @@ export function errorHandler(
   err: AppError,
   req: Request,
   res: Response,
-  _: NextFunction
+  // eslint-disable-next-line no-unused-vars
+  _next: NextFunction
 ): void {
   const statusCode = err.statusCode || 500
   const isOperational = err.isOperational || false

--- a/backend/src/middleware/notFoundHandler.ts
+++ b/backend/src/middleware/notFoundHandler.ts
@@ -1,6 +1,10 @@
 import { Request, Response, NextFunction } from 'express'
 
-export function notFoundHandler(req: Request, res: Response, _: NextFunction): void {
+export function notFoundHandler(
+  req: Request,
+  res: Response,
+  _next: NextFunction // eslint-disable-line no-unused-vars
+): void {
   const error = {
     success: false,
     error: {


### PR DESCRIPTION
## Summary
- chore: remove unused imports and schemas in UVAController
- chore: silence unused next parameters in Express middlewares

## Testing
- `npm run lint:complexity` *(fails: max-lines-per-function, parsing errors)*
- `npm run lint:duplicates` *(fails: TypeError: isFullwidthCodePoint is not a function)*
- `npm test` *(fails: no such table: goal_optimization_strategies)*
- `npm run backend:build` *(fails: Property 'commissionAmount' does not exist on type 'TradeData')*

------
https://chatgpt.com/codex/tasks/task_e_68c41e47ae488327b57e90e9ee31af7b