### PR TITLE
Ajustes de controladores y exportación en módulo de objetivos

### DIFF
--- a/backend/src/controllers/GoalOptimizerController.ts
+++ b/backend/src/controllers/GoalOptimizerController.ts
@@ -159,12 +159,24 @@ export class GoalOptimizerController {
         });
       }
 
-      const customData: CreateGapAnalysisDto = req.body;
-      const gapAnalysis = await this.optimizerService.performGapAnalysis(goalId, customData);
+      const customData = (req.body ?? {}) as Partial<CreateGapAnalysisDto>;
+
+      if (customData.goal_id && customData.goal_id !== goalId) {
+        return res.status(400).json({
+          success: false,
+          error: 'El ID del cuerpo no coincide con el objetivo solicitado'
+        });
+      }
+
+      const gapAnalysis = await this.optimizerService.performGapAnalysis(goalId);
+
+      const responseAnalysis = customData.analysis_details
+        ? { ...gapAnalysis, analysis_details: customData.analysis_details }
+        : gapAnalysis;
 
       return res.json({
         success: true,
-        data: gapAnalysis,
+        data: responseAnalysis,
         message: 'Análisis de gap completado exitosamente'
       });
     } catch (error: any) {


### PR DESCRIPTION
## Summary
- valida el id del objetivo en el controlador de optimización y permite fusionar detalles personalizados sin romper el análisis automático
- encapsula el retorno de proyecciones en caché para reducir la complejidad del controlador de proyecciones
- normaliza las fechas y aprovecha las opciones de exportación al generar planes e informes en GoalExportService

## Testing
- `npm run type-check` *(falla por errores existentes en módulos no modificados)*
- `npx eslint backend/src/controllers/GoalOptimizerController.ts backend/src/controllers/GoalProjectionController.ts backend/src/services/GoalExportService.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c857b3271083278c5bd0b7e79b5bda