### PR TITLE
Fix goal module type issues

### DIFF
--- a/backend/src/services/GoalAccelerationService.ts
+++ b/backend/src/services/GoalAccelerationService.ts
@@ -30,7 +30,7 @@ export class GoalAccelerationService {
   constructor(db: Database.Database) {
     this.db = db;
     this.goalTrackerService = new GoalTrackerService(db);
-    this.portfolioService = new PortfolioService(db);
+    this.portfolioService = new PortfolioService();
     this.opportunityService = new OpportunityService();
     this.technicalAnalysisService = new TechnicalAnalysisService();
   }
@@ -152,7 +152,7 @@ export class GoalAccelerationService {
       risk_increase_factor: 1.0, // Sin aumento de riesgo
       complexity_score: 3, // Baja complejidad
       capital_requirements: 0,
-      expected_return_boost: null, // No aumenta retorno, reduce costos
+      expected_return_boost: 0, // No aumenta retorno, reduce costos
       implementation_timeline_days: 14
     };
   }
@@ -522,7 +522,7 @@ export class GoalAccelerationService {
   private async getCurrentCapital(): Promise<number> {
     try {
       const summary = await this.portfolioService.getPortfolioSummary();
-      return summary.totalValue || 25000;
+      return summary.market_value || summary.total_cost || 25000;
     } catch (error) {
       logger.warn('No se pudo obtener el valor del portafolio, usando 25000 por defecto', error)
       return 25000;

--- a/frontend/src/components/goals/GoalDashboard.tsx
+++ b/frontend/src/components/goals/GoalDashboard.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Card } from '../ui/Card';
 import { Button } from '../ui/Button';
 import { Badge } from '../ui/Badge';

--- a/frontend/src/hooks/useGoalOptimizer.ts
+++ b/frontend/src/hooks/useGoalOptimizer.ts
@@ -4,7 +4,7 @@
  */
 
 import { useState, useEffect, useCallback } from 'react';
-import { 
+import {
   goalOptimizerService,
   type GapAnalysis,
   type OptimizationStrategy,
@@ -15,6 +15,17 @@ import {
   type OptimizerSummary,
   type PersonalizedRecommendation
 } from '../services/goalOptimizerService';
+
+type GoalOptimizerErrorKey =
+  | 'summary'
+  | 'refresh'
+  | 'gapAnalysis'
+  | 'strategies'
+  | 'plans'
+  | 'milestones'
+  | 'acceleration'
+  | 'opportunities'
+  | 'recommendations';
 
 export interface UseGoalOptimizerOptions {
   autoRefresh?: boolean;
@@ -47,15 +58,7 @@ export interface GoalOptimizerState {
   
   // Errores
   error: string | null;
-  errors: {
-    summary?: string;
-    gapAnalysis?: string;
-    strategies?: string;
-    plans?: string;
-    milestones?: string;
-    acceleration?: string;
-    opportunities?: string;
-  };
+  errors: Partial<Record<GoalOptimizerErrorKey, string>>;
 
   // Métricas calculadas
   metrics: {
@@ -132,7 +135,7 @@ export interface UseGoalOptimizerReturn extends GoalOptimizerState {
   }) => Promise<void>;
 
   // Utilidades
-  clearError: (type?: string) => void;
+  clearError: (type?: GoalOptimizerErrorKey) => void;
   forceRefresh: () => Promise<void>;
 }
 
@@ -216,7 +219,7 @@ export const useGoalOptimizer = (
   }, []);
 
   // Función para manejar errores
-  const handleError = useCallback((error: any, type: string) => {
+  const handleError = useCallback((error: any, type: GoalOptimizerErrorKey) => {
     const errorMessage = error.response?.data?.error || error.message || 'Error desconocido';
     console.error(`Error in ${type}:`, error);
     
@@ -450,7 +453,7 @@ export const useGoalOptimizer = (
   }, [goalId, updateState, handleError]);
 
   // Utilidades
-  const clearError = useCallback((type?: string) => {
+  const clearError = useCallback((type?: GoalOptimizerErrorKey) => {
     if (type) {
       updateState({ 
         errors: { ...state.errors, [type]: undefined },


### PR DESCRIPTION
## Summary
- align `GoalAccelerationService` with available services and guard portfolio fallback values
- relax goal optimizer hook error typing to accept known categories and clean dashboard import

## Testing
- npm run backend:build *(fails: existing TypeScript errors remain)*
- npm run frontend:build *(fails: existing TypeScript errors remain)*

------
https://chatgpt.com/codex/tasks/task_e_68c95d77269483278dae3eee744aec4c