### PR TITLE
Fix opportunity hook imports and clean unused React imports

### DIFF
--- a/frontend/src/components/opportunities/DiversificationCalculator.tsx
+++ b/frontend/src/components/opportunities/DiversificationCalculator.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import { useState, useEffect } from 'react'
 import { 
   Calculator, 
   AlertTriangle, 

--- a/frontend/src/components/opportunities/OpportunityScoreBreakdown.tsx
+++ b/frontend/src/components/opportunities/OpportunityScoreBreakdown.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { 
   BarChart3, 
   TrendingUp, 

--- a/frontend/src/hooks/useOpportunities.ts
+++ b/frontend/src/hooks/useOpportunities.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { opportunityService } from '../services/opportunityService'
-import { useApi } from './useApi'
+import { useAppStore } from '../store'
 
 export interface OpportunityData {
   id: number
@@ -135,9 +135,11 @@ export interface CommissionImpact {
   is_profitable: boolean
 }
 
+const useOnlineStatus = () => useAppStore((state) => state.config.isOnline)
+
 export function useOpportunities() {
   const queryClient = useQueryClient()
-  const { isOnline } = useApi()
+  const isOnline = useOnlineStatus()
 
   // Query para oportunidades del día
   const {
@@ -304,7 +306,7 @@ export function useOpportunities() {
 
 // Hook específico para una oportunidad individual
 export function useOpportunityDetail(id: number) {
-  const { isOnline } = useApi()
+  const isOnline = useOnlineStatus()
   
   return useQuery({
     queryKey: ['opportunities', 'detail', id],
@@ -354,7 +356,7 @@ export function useDiversificationCalculator() {
 
 // Hook para estadísticas en tiempo real
 export function useOpportunityStatsRealtime() {
-  const { isOnline } = useApi()
+  const isOnline = useOnlineStatus()
   
   return useQuery({
     queryKey: ['opportunities', 'stats', 'realtime'],


### PR DESCRIPTION
## Summary
- remove unused default React imports from opportunity UI components now that the project uses the automatic JSX runtime
- update `useOpportunities` to read the online status from the global store instead of a missing `useApi` hook

## Testing
- npm run frontend:lint
- npx tsc --noEmit --pretty false *(fails: existing scenario analysis, animated list, and other unrelated TypeScript errors remain)*

------
https://chatgpt.com/codex/tasks/task_e_68c97e6d36048327ba4c9692084a03cf