### PR TITLE
Align opportunity services with type-safe market data

### DIFF
--- a/backend/src/models/Opportunity.ts
+++ b/backend/src/models/Opportunity.ts
@@ -1,5 +1,6 @@
 import SimpleDatabaseConnection from '../database/simple-connection.js'
 import { createLogger } from '../utils/logger.js'
+import type { OpportunityTechnicalTag } from '../types/opportunity.js'
 
 const logger = createLogger('Opportunity')
 
@@ -10,6 +11,7 @@ export interface OpportunityData {
   company_name: string
   opportunity_type: 'BUY' | 'STRONG_BUY'
   composite_score: number
+  sector?: string
   technical_signals: {
     rsi: {
       value: number
@@ -50,6 +52,8 @@ export interface OpportunityData {
     volume_avg: number
     volume_current: number
     market_cap?: number
+    price_change_24h?: number
+    price_change_percentage_24h?: number
   }
   esg_criteria: {
     is_esg_compliant: boolean
@@ -67,6 +71,17 @@ export interface OpportunityData {
     time_horizon_days: number
     confidence_level: number
   }
+  min_investment?: number
+  confidence_score?: number
+  price_change_1m?: number
+  price_change_3m?: number
+  current_price?: number
+  target_price?: number
+  stop_loss?: number
+  volatility?: number
+  has_earnings_growth?: boolean
+  has_upcoming_earnings?: boolean
+  technical_tags?: OpportunityTechnicalTag[]
   detected_at: string
   expires_at: string
   is_active: boolean
@@ -74,7 +89,7 @@ export interface OpportunityData {
   updated_at?: string
 }
 
-export interface OpportunityCreateInput extends Omit<OpportunityData, 'id' | 'ranking' | 'created_at' | 'updated_at'> {}
+export interface OpportunityCreateInput extends Omit<OpportunityData, 'id' | 'created_at' | 'updated_at'> {}
 
 export interface OpportunityFilters {
   minScore?: number

--- a/backend/src/types/opportunity.ts
+++ b/backend/src/types/opportunity.ts
@@ -158,6 +158,13 @@ export enum SignalStrength {
   VERY_STRONG = 'VERY_STRONG'
 }
 
+export type OpportunityTechnicalTag =
+  | 'TECHNICAL_BREAKOUT'
+  | 'VALUE_PLAY'
+  | 'DIVIDEND_ARISTOCRAT'
+  | 'EARNINGS_MOMENTUM'
+  | 'OVERSOLD_BOUNCE'
+
 // Interfaces para requests/responses de API
 export interface CreateOpportunityRequest {
   symbol: string


### PR DESCRIPTION
## Summary
- harden opportunity scanning to guard market metrics and emit derived tags
- extend opportunity records with optional analytics fields consumed downstream
- expose type-safe opportunity metadata helpers for reuse in integration services

## Testing
- npx tsc --pretty false *(fails: existing TypeScript errors in other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68caba13ca7c83278dd756b145bdcbd0