### PR TITLE
Fix type issues in animated UI components

### DIFF
--- a/frontend/src/components/ui/AnimatedCard.tsx
+++ b/frontend/src/components/ui/AnimatedCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { motion, AnimatePresence, HTMLMotionProps } from 'framer-motion'
+import type { Variants } from 'framer-motion'
 import { cn } from '../../utils/cn'
 
 interface AnimatedCardProps extends Omit<HTMLMotionProps<"div">, 'children'> {
@@ -12,7 +13,7 @@ interface AnimatedCardProps extends Omit<HTMLMotionProps<"div">, 'children'> {
   variant?: 'fade' | 'slide' | 'scale' | 'bounce'
 }
 
-const cardVariants = {
+const cardVariants: Record<NonNullable<AnimatedCardProps['variant']>, Variants> = {
   fade: {
     hidden: { opacity: 0 },
     visible: { opacity: 1 }
@@ -39,8 +40,8 @@ const cardVariants = {
   }
 }
 
-const hoverVariants = {
-  hover: { 
+const hoverVariants: Variants = {
+  hover: {
     scale: 1.02,
     transition: {
       type: "spring",
@@ -61,24 +62,26 @@ export const AnimatedCard: React.FC<AnimatedCardProps> = ({
   variant = 'fade',
   ...props
 }) => {
-  const motionProps = {
+  const baseVariants = cardVariants[variant]
+  const motionProps: HTMLMotionProps<'div'> = {
     initial: "hidden",
     animate: "visible",
-    variants: cardVariants[variant],
+    variants: baseVariants,
     transition: {
       duration: 0.4,
       delay,
-      ease: "easeOut"
+      ease: 'easeOut' as const
     },
-    ...(hover && {
-      whileHover: "hover",
-      whileTap: "tap",
-      variants: {
-        ...cardVariants[variant],
-        ...hoverVariants
-      }
-    }),
     ...props
+  }
+
+  if (hover) {
+    motionProps.whileHover = "hover"
+    motionProps.whileTap = "tap"
+    motionProps.variants = {
+      ...baseVariants,
+      ...hoverVariants
+    }
   }
 
   return (

--- a/frontend/src/components/ui/AnimatedList.tsx
+++ b/frontend/src/components/ui/AnimatedList.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { motion, AnimatePresence, LayoutGroup } from 'framer-motion'
+import type { Variants, TargetAndTransition } from 'framer-motion'
 import { cn } from '../../utils/cn'
 
 interface AnimatedListProps {
@@ -10,7 +11,9 @@ interface AnimatedListProps {
   variant?: 'fade' | 'slide' | 'scale'
 }
 
-const listVariants = {
+type AnimatedListVariant = NonNullable<AnimatedListProps['variant']>
+
+const listVariants: Record<AnimatedListVariant, Variants> = {
   fade: {
     hidden: { opacity: 0 },
     visible: { opacity: 1 },
@@ -35,11 +38,15 @@ export const AnimatedList: React.FC<AnimatedListProps> = ({
   layout = true,
   variant: _variant = 'slide'
 }) => {
+  const variant = _variant
+  const baseVariant = listVariants[variant]
+  const visibleVariant = baseVariant.visible as TargetAndTransition | undefined
   const containerVariants = {
-    ...listVariants[variant],
+    ...baseVariant,
     visible: {
-      ...listVariants[variant].visible,
+      ...(visibleVariant ?? {}),
       transition: {
+        ...(visibleVariant?.transition ?? {}),
         staggerChildren: staggerDelay
       }
     }
@@ -88,7 +95,7 @@ export const AnimatedListItem: React.FC<{
     variants: listVariants[variant],
     transition: {
       duration: 0.3,
-      ease: "easeOut"
+      ease: 'easeOut' as const
     },
     className: className,
     ...(layout && { layout: true }),


### PR DESCRIPTION
## Summary
- tighten the animation variant typing for the shared AnimatedList component to remove implicit `any` usage
- adjust AnimatedCard motion props to use typed variants and literal easing values compatible with framer-motion

## Testing
- npm run type-check *(fails: existing TypeScript errors in other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68cb03d141408327b38964750999285b