### PR TITLE
Handle function variants in AnimatedList

### DIFF
--- a/frontend/src/components/TechnicalIndicators/TechnicalChart.tsx
+++ b/frontend/src/components/TechnicalIndicators/TechnicalChart.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { type ReactElement, useState } from 'react'
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceLine } from 'recharts'
 import { useIndicatorHistory, useExtremes } from '../../hooks/useTechnicalIndicators'
 import { Card } from '../ui/Card'
@@ -87,6 +87,27 @@ export function TechnicalChart({ symbol, height = 300, showControls = true }: Te
     signal: indicator.signal,
     strength: indicator.strength
   })) || []
+
+  const renderSignalDot = (props: any): ReactElement<SVGElement> => {
+    const { payload, cx = 0, cy = 0 } = props || {}
+
+    const color = payload?.signal === 'BUY'
+      ? '#22c55e'
+      : payload?.signal === 'SELL'
+        ? '#ef4444'
+        : '#6b7280'
+
+    return (
+      <circle
+        cx={cx}
+        cy={cy}
+        r={payload ? 3 : 0}
+        fill={color}
+        stroke={color}
+        strokeWidth={1}
+      />
+    )
+  }
 
   const getReferenceLines = () => {
     if (selectedIndicator === 'RSI') {
@@ -206,24 +227,7 @@ export function TechnicalChart({ symbol, height = 300, showControls = true }: Te
                 dataKey="value"
                 stroke={getIndicatorColor(selectedIndicator)}
                 strokeWidth={2}
-                dot={(props: any) => {
-                  const { payload } = props
-                  if (!payload) return null
-                  
-                  const color = payload.signal === 'BUY' ? '#22c55e' : 
-                               payload.signal === 'SELL' ? '#ef4444' : '#6b7280'
-                  
-                  return (
-                    <circle
-                      cx={props.cx}
-                      cy={props.cy}
-                      r={3}
-                      fill={color}
-                      stroke={color}
-                      strokeWidth={1}
-                    />
-                  )
-                }}
+                dot={renderSignalDot}
                 activeDot={{ r: 5, stroke: getIndicatorColor(selectedIndicator), strokeWidth: 2 }}
               />
             </LineChart>

--- a/frontend/src/components/ui/AnimatedCard.tsx
+++ b/frontend/src/components/ui/AnimatedCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { motion, AnimatePresence, HTMLMotionProps } from 'framer-motion'
+import type { Variants } from 'framer-motion'
 import { cn } from '../../utils/cn'
 
 interface AnimatedCardProps extends Omit<HTMLMotionProps<"div">, 'children'> {
@@ -12,7 +13,7 @@ interface AnimatedCardProps extends Omit<HTMLMotionProps<"div">, 'children'> {
   variant?: 'fade' | 'slide' | 'scale' | 'bounce'
 }
 
-const cardVariants = {
+const cardVariants: Record<NonNullable<AnimatedCardProps['variant']>, Variants> = {
   fade: {
     hidden: { opacity: 0 },
     visible: { opacity: 1 }
@@ -39,8 +40,8 @@ const cardVariants = {
   }
 }
 
-const hoverVariants = {
-  hover: { 
+const hoverVariants: Variants = {
+  hover: {
     scale: 1.02,
     transition: {
       type: "spring",
@@ -61,24 +62,26 @@ export const AnimatedCard: React.FC<AnimatedCardProps> = ({
   variant = 'fade',
   ...props
 }) => {
-  const motionProps = {
+  const baseVariants = cardVariants[variant]
+  const motionProps: HTMLMotionProps<'div'> = {
     initial: "hidden",
     animate: "visible",
-    variants: cardVariants[variant],
+    variants: baseVariants,
     transition: {
       duration: 0.4,
       delay,
-      ease: "easeOut"
+      ease: 'easeOut' as const
     },
-    ...(hover && {
-      whileHover: "hover",
-      whileTap: "tap",
-      variants: {
-        ...cardVariants[variant],
-        ...hoverVariants
-      }
-    }),
     ...props
+  }
+
+  if (hover) {
+    motionProps.whileHover = "hover"
+    motionProps.whileTap = "tap"
+    motionProps.variants = {
+      ...baseVariants,
+      ...hoverVariants
+    }
   }
 
   return (

--- a/frontend/src/components/ui/AnimatedList.tsx
+++ b/frontend/src/components/ui/AnimatedList.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { motion, AnimatePresence, LayoutGroup } from 'framer-motion'
-import type { Variants } from 'framer-motion'
+import type { Variants, TargetAndTransition } from 'framer-motion'
 import { cn } from '../../utils/cn'
 
 interface AnimatedListProps {
@@ -31,57 +31,6 @@ const listVariants: Record<AnimatedListVariant, Variants> = {
   }
 }
 
-type VariantValue = Variants[string]
-
-const applyStaggerToVariant = (
-  variant: VariantValue,
-  staggerDelay: number
-): VariantValue => {
-  if (!variant) {
-    return variant
-  }
-
-  if (typeof variant === 'function') {
-    const resolver = variant as (...args: any[]) => VariantValue
-
-    return ((...args: any[]) => {
-      const resolved = resolver(...args)
-
-      if (!resolved || typeof resolved !== 'object') {
-        return resolved
-      }
-
-      const resolvedObject = resolved as {
-        transition?: Record<string, unknown>
-      }
-
-      return {
-        ...resolvedObject,
-        transition: {
-          ...(resolvedObject.transition ?? {}),
-          staggerChildren: staggerDelay
-        }
-      } as VariantValue
-    }) as VariantValue
-  }
-
-  if (typeof variant !== 'object') {
-    return variant
-  }
-
-  const variantObject = variant as {
-    transition?: Record<string, unknown>
-  }
-
-  return {
-    ...variantObject,
-    transition: {
-      ...(variantObject.transition ?? {}),
-      staggerChildren: staggerDelay
-    }
-  } as VariantValue
-}
-
 export const AnimatedList: React.FC<AnimatedListProps> = ({
   children,
   className,
@@ -89,15 +38,22 @@ export const AnimatedList: React.FC<AnimatedListProps> = ({
   layout = true,
   variant: _variant = 'slide'
 }) => {
-  const variantKey = _variant
+  const variant = _variant
   const containerVariants = React.useMemo<Variants>(() => {
-    const baseVariant = listVariants[variantKey]
+    const baseVariant = listVariants[variant]
+    const visibleVariant = baseVariant.visible as TargetAndTransition | undefined
 
     return {
       ...baseVariant,
-      visible: applyStaggerToVariant(baseVariant.visible, staggerDelay)
+      visible: {
+        ...(visibleVariant ?? {}),
+        transition: {
+          ...(visibleVariant?.transition ?? {}),
+          staggerChildren: staggerDelay
+        }
+      }
     }
-  }, [variantKey, staggerDelay])
+  }, [variant, staggerDelay])
 
   const content = layout ? (
     <LayoutGroup>

--- a/frontend/src/components/ui/AnimatedList.tsx
+++ b/frontend/src/components/ui/AnimatedList.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { motion, AnimatePresence, LayoutGroup } from 'framer-motion'
+import type { Variants } from 'framer-motion'
 import { cn } from '../../utils/cn'
 
 interface AnimatedListProps {
@@ -10,7 +11,9 @@ interface AnimatedListProps {
   variant?: 'fade' | 'slide' | 'scale'
 }
 
-const listVariants = {
+type AnimatedListVariant = NonNullable<AnimatedListProps['variant']>
+
+const listVariants: Record<AnimatedListVariant, Variants> = {
   fade: {
     hidden: { opacity: 0 },
     visible: { opacity: 1 },
@@ -35,11 +38,17 @@ export const AnimatedList: React.FC<AnimatedListProps> = ({
   layout = true,
   variant: _variant = 'slide'
 }) => {
+  const variant = _variant
+  const baseVariant = listVariants[variant]
+  const visibleVariant = baseVariant.visible
+  const visibleTarget =
+    typeof visibleVariant === 'function' ? undefined : visibleVariant
   const containerVariants = {
-    ...listVariants[variant],
+    ...baseVariant,
     visible: {
-      ...listVariants[variant].visible,
+      ...(visibleTarget ?? {}),
       transition: {
+        ...(visibleTarget?.transition ?? {}),
         staggerChildren: staggerDelay
       }
     }
@@ -88,7 +97,7 @@ export const AnimatedListItem: React.FC<{
     variants: listVariants[variant],
     transition: {
       duration: 0.3,
-      ease: "easeOut"
+      ease: 'easeOut' as const
     },
     className: className,
     ...(layout && { layout: true }),

--- a/frontend/src/hooks/useReports.ts
+++ b/frontend/src/hooks/useReports.ts
@@ -305,6 +305,11 @@ export function useDateRangeManager(initialRange?: DateRange) {
 export function useReportsCache() {
   const queryClient = useQueryClient();
 
+  const isDateRangeIdentifier = (
+    identifier: DateRange | number | undefined
+  ): identifier is DateRange =>
+    typeof identifier === 'object' && identifier !== null && 'startDate' in identifier;
+
   const clearAllReportsCache = () => {
     queryClient.removeQueries({ queryKey: REPORTS_QUERY_KEYS.all });
   };
@@ -312,17 +317,17 @@ export function useReportsCache() {
   const clearReportCache = (reportType: ReportType, identifier?: DateRange | number) => {
     switch (reportType) {
       case 'dashboard':
-        if (identifier && 'startDate' in identifier) {
+        if (isDateRangeIdentifier(identifier)) {
           queryClient.removeQueries({ queryKey: REPORTS_QUERY_KEYS.dashboard(identifier) });
         }
         break;
       case 'impact_analysis':
-        if (identifier && 'startDate' in identifier) {
+        if (isDateRangeIdentifier(identifier)) {
           queryClient.removeQueries({ queryKey: REPORTS_QUERY_KEYS.impactAnalysis(identifier) });
         }
         break;
       case 'commission_comparison':
-        if (identifier && 'startDate' in identifier) {
+        if (isDateRangeIdentifier(identifier)) {
           queryClient.removeQueries({ queryKey: REPORTS_QUERY_KEYS.commissionComparison(identifier) });
         }
         break;

--- a/frontend/src/hooks/useTechnicalIndicators.ts
+++ b/frontend/src/hooks/useTechnicalIndicators.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { technicalIndicatorService, type TechnicalIndicatorFilters, type ActiveSignalsFilters, type CalculateIndicatorsRequest } from '../services/technicalIndicatorService'
+import { technicalIndicatorService, type TechnicalIndicatorFilters, type ActiveSignalsFilters, type CalculateIndicatorsRequest, type TechnicalIndicatorHistory } from '../services/technicalIndicatorService'
 
 export const TECHNICAL_INDICATORS_KEYS = {
   all: ['technical-indicators'] as const,
@@ -31,7 +31,7 @@ export function useLatestIndicators(symbol: string, filters?: TechnicalIndicator
 /**
  * Hook para obtener el historial de indicadores técnicos
  */
-export function useIndicatorHistory(symbol: string, filters?: { indicator?: string; days?: number; limit?: number }) {
+export function useIndicatorHistory(symbol: string, filters?: TechnicalIndicatorHistory) {
   return useQuery({
     queryKey: TECHNICAL_INDICATORS_KEYS.history(symbol, filters || {}),
     queryFn: () => technicalIndicatorService.getIndicatorHistory(symbol, filters),
@@ -113,7 +113,7 @@ export function useCalculateIndicators() {
   return useMutation({
     mutationFn: (request: CalculateIndicatorsRequest) => 
       technicalIndicatorService.calculateIndicators(request),
-    onSuccess: (data, variables) => {
+    onSuccess: (_result, variables) => {
       // Invalidar caché relacionado
       if (variables.symbol) {
         queryClient.invalidateQueries({ 


### PR DESCRIPTION
## Summary
- remove the redundant TargetAndTransition import and cast in AnimatedList
- guard against function-based variants before reading transition settings so lints pass without assertions

## Testing
- npm run type-check *(fails: existing TypeScript errors in other frontend modules)*

------
https://chatgpt.com/codex/tasks/task_e_68cb03d141408327b38964750999285b