### PR TITLE
Refine ESG evaluation services to resolve type issues

### DIFF
--- a/backend/src/services/ESGAnalysisService.ts
+++ b/backend/src/services/ESGAnalysisService.ts
@@ -530,7 +530,7 @@ export class ESGAnalysisService {
       summary,
       keyPoints?.length && `Key points: ${keyPoints.join('; ')}`,
       strategicRecommendations?.length && `Recommendations: ${strategicRecommendations.join('; ')}`
-    ].filter((part): part is string => Boolean(part)).join('\n')
+    ].filter((part): part is string => typeof part === 'string' && part.length > 0).join('\n')
   }
 
   private async withRateLimit<T>(requestId: string, fn: () => Promise<T>): Promise<T> {
@@ -564,7 +564,7 @@ export class ESGAnalysisService {
       this.createYahooSource(data.yahooData),
       this.createSustainalyticsSource(data.sustainalyticsData),
       this.createNewsSource(data.newsData)
-    ].filter((source): source is SourceContribution => Boolean(source))
+    ].filter((source): source is SourceContribution => source != null)
   }
 
   private createYahooSource(yahooData: any): SourceContribution | null {

--- a/backend/src/services/ESGAnalysisService.ts
+++ b/backend/src/services/ESGAnalysisService.ts
@@ -358,13 +358,13 @@ export class ESGAnalysisService {
     }
 
     let totalConfidence = 0
-    sources.forEach(source => {
+    for (const source of sources) {
       scores.environmental += source.contributions.environmental
       scores.social += source.contributions.social
       scores.governance += source.contributions.governance
       dataSources.push(source.label)
       totalConfidence += source.confidence
-    })
+    }
 
     const sourceCount = sources.length
     const controversyPenalty = this.calculateControversyPenalty(data.controversies)
@@ -590,11 +590,17 @@ export class ESGAnalysisService {
 
   private calculateControversyPenalty(controversies: ESGControversy[]): number {
     return controversies.reduce((penalty, controversy) => {
-      const severityFactor = controversy.severity === 'CRITICAL' ? 0.5
-        : controversy.severity === 'HIGH' ? 0.3
-          : controversy.severity === 'MEDIUM' ? 0.1
-            : 0.05
-      return penalty + (controversy.impact * severityFactor)
+      let severityFactor = 0.05
+
+      if (controversy.severity === 'CRITICAL') {
+        severityFactor = 0.5
+      } else if (controversy.severity === 'HIGH') {
+        severityFactor = 0.3
+      } else if (controversy.severity === 'MEDIUM') {
+        severityFactor = 0.1
+      }
+
+      return penalty + controversy.impact * severityFactor
     }, 0)
   }
 

--- a/backend/src/services/ESGAnalysisService.ts
+++ b/backend/src/services/ESGAnalysisService.ts
@@ -52,7 +52,7 @@ export class ESGAnalysisService {
   private instrumentModel = new InstrumentModel()
   private claudeService = new ClaudeContextualService()
   private newsService = new NewsAnalysisService()
-  private rateLimiter = new RateLimitService()
+  private readonly rateLimiter = new RateLimitService()
 
   private readonly DATA_SOURCES: ESGDataSource[] = [
     { name: 'Yahoo Finance ESG', type: 'API', url: 'https://query1.finance.yahoo.com/v1/finance/esgChart', reliability: 85 },

--- a/backend/src/services/VeganAnalysisService.ts
+++ b/backend/src/services/VeganAnalysisService.ts
@@ -265,11 +265,15 @@ export class VeganAnalysisService {
   /**
    * Analyze vegan-related news using Claude
    */
-  private async getVeganNewsAnalysis(): Promise<any> {
+  private async getVeganNewsAnalysis(symbol: string, companyName: string): Promise<any> {
+    void symbol
+    void companyName
     return null
   }
 
-  private async detectVeganViolations(): Promise<VeganViolation[]> {
+  private async detectVeganViolations(symbol: string, companyName: string): Promise<VeganViolation[]> {
+    void symbol
+    void companyName
     return []
   }
 

--- a/backend/src/services/VeganAnalysisService.ts
+++ b/backend/src/services/VeganAnalysisService.ts
@@ -266,14 +266,12 @@ export class VeganAnalysisService {
    * Analyze vegan-related news using Claude
    */
   private async getVeganNewsAnalysis(symbol: string, companyName: string): Promise<any> {
-    void symbol
-    void companyName
+    logger.debug(`No vegan news analysis available for ${symbol} (${companyName})`)
     return null
   }
 
   private async detectVeganViolations(symbol: string, companyName: string): Promise<VeganViolation[]> {
-    void symbol
-    void companyName
+    logger.debug(`No vegan violation sources configured for ${symbol} (${companyName})`)
     return []
   }
 


### PR DESCRIPTION
## Summary
- ensure ESG analysis waits on instrument lookups, wraps external calls with a reusable rate limiter, and derives text summaries safely from Claude responses【F:backend/src/services/ESGAnalysisService.ts†L70-L145】【F:backend/src/services/ESGAnalysisService.ts†L187-L243】【F:backend/src/services/ESGAnalysisService.ts†L393-L423】【F:backend/src/services/ESGAnalysisService.ts†L578-L596】
- fix the ESG/Vegan evaluation job to await instrument access, respect scheduling flags, and report job status without relying on unavailable cron APIs【F:backend/src/jobs/ESGVeganEvaluationJob.ts†L20-L85】【F:backend/src/jobs/ESGVeganEvaluationJob.ts†L236-L320】【F:backend/src/jobs/ESGVeganEvaluationJob.ts†L411-L439】
- accept instrument context in vegan analysis helpers so they no longer violate method signatures【F:backend/src/services/VeganAnalysisService.ts†L268-L277】

## Testing
- `npm run backend:build` *(fails: existing compilation issues remain in other modules)*【eebd98†L1-L116】

------
https://chatgpt.com/codex/tasks/task_e_68d2d60faca08327839cf501c87cc128