### PR TITLE
Fix technical analysis service type safety

### DIFF
--- a/backend/src/services/cacheService.ts
+++ b/backend/src/services/cacheService.ts
@@ -129,6 +129,27 @@ export class CacheService {
   }
 
   /**
+   * Elimina entradas cuyo key comparte un prefijo
+   */
+  clearByPrefix(prefix: string): number {
+    let removed = 0
+
+    for (const key of Array.from(this.cache.keys())) {
+      if (key.startsWith(prefix)) {
+        this.cache.delete(key)
+        removed++
+      }
+    }
+
+    if (removed > 0) {
+      this.updateStats()
+      logger.info('Cache entries cleared by prefix', { prefix, removed })
+    }
+
+    return removed
+  }
+
+  /**
    * Genera una clave de caché para análisis de Claude
    */
   generateAnalysisKey(prompt: string, instrumentCode?: string, context?: string): string {


### PR DESCRIPTION
## Summary
- refactor technical analysis service to compute extremes directly from price history and guard against undefined price data
- adjust trend prediction service to reuse the same quote history mapping and rely on available technical indicator APIs
- add cacheService.clearByPrefix to support targeted cache invalidation across services

## Testing
- npm run backend:build *(fails: 166 TypeScript errors remain outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68d454f83c7c83278253f0e9b63cc2ae