### PR TITLE
Fix reporting hook TypeScript regressions

### DIFF
--- a/frontend/src/hooks/useMonthlyReview.ts
+++ b/frontend/src/hooks/useMonthlyReview.ts
@@ -148,7 +148,7 @@ export function useMonthlyReview(offset = 0, limit = 50) {
   const applyChanges = useMutation({
     mutationFn: ({ reviewId, dryRun = false }: { reviewId: number, dryRun?: boolean }) => 
       monthlyReviewService.applyChanges(reviewId, dryRun),
-    onSuccess: (data, variables) => {
+    onSuccess: (_data, variables) => {
       // If not a dry run, invalidate all relevant data
       if (!variables.dryRun) {
         queryClient.invalidateQueries({ queryKey: monthlyReviewKeys.all })

--- a/frontend/src/hooks/useReports.ts
+++ b/frontend/src/hooks/useReports.ts
@@ -309,20 +309,24 @@ export function useReportsCache() {
     queryClient.removeQueries({ queryKey: REPORTS_QUERY_KEYS.all });
   };
 
+  const isDateRange = (value: DateRange | number | undefined): value is DateRange => {
+    return typeof value === 'object' && value !== null && 'startDate' in value && 'endDate' in value;
+  };
+
   const clearReportCache = (reportType: ReportType, identifier?: DateRange | number) => {
     switch (reportType) {
       case 'dashboard':
-        if (identifier && 'startDate' in identifier) {
+        if (isDateRange(identifier)) {
           queryClient.removeQueries({ queryKey: REPORTS_QUERY_KEYS.dashboard(identifier) });
         }
         break;
       case 'impact_analysis':
-        if (identifier && 'startDate' in identifier) {
+        if (isDateRange(identifier)) {
           queryClient.removeQueries({ queryKey: REPORTS_QUERY_KEYS.impactAnalysis(identifier) });
         }
         break;
       case 'commission_comparison':
-        if (identifier && 'startDate' in identifier) {
+        if (isDateRange(identifier)) {
           queryClient.removeQueries({ queryKey: REPORTS_QUERY_KEYS.commissionComparison(identifier) });
         }
         break;


### PR DESCRIPTION
## Summary
- adjust the monthly review mutation success handler to avoid unused parameters reported by TypeScript
- harden the reports cache utilities with a date-range type guard to satisfy strict union checks
- refactor the sector balance auto-refresh hook to drive cache invalidation via useEffect instead of an unsupported onSuccess callback

## Testing
- npm run frontend:build *(fails: remaining compile errors in technical indicators, instrument limit manager imports, and notification service)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a0ba1ca48327856b63e3dd3bde99