### PR TITLE
Fix technical indicator hook and chart typings

### DIFF
--- a/frontend/src/components/TechnicalIndicators/TechnicalChart.tsx
+++ b/frontend/src/components/TechnicalIndicators/TechnicalChart.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react'
-import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceLine } from 'recharts'
+import { useState, type ReactElement } from 'react'
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, ReferenceLine, type DotProps } from 'recharts'
 import { useIndicatorHistory, useExtremes } from '../../hooks/useTechnicalIndicators'
 import { Card } from '../ui/Card'
 import { Button } from '../ui/Button'
@@ -206,17 +206,17 @@ export function TechnicalChart({ symbol, height = 300, showControls = true }: Te
                 dataKey="value"
                 stroke={getIndicatorColor(selectedIndicator)}
                 strokeWidth={2}
-                dot={(props: any) => {
-                  const { payload } = props
-                  if (!payload) return null
-                  
-                  const color = payload.signal === 'BUY' ? '#22c55e' : 
-                               payload.signal === 'SELL' ? '#ef4444' : '#6b7280'
-                  
+                dot={(props: DotProps): ReactElement => {
+                  const { payload } = props as DotProps & { payload?: { signal?: 'BUY' | 'SELL' } }
+                  const signal = payload?.signal
+                  const color = signal === 'BUY' ? '#22c55e'
+                    : signal === 'SELL' ? '#ef4444'
+                    : '#6b7280'
+
                   return (
                     <circle
-                      cx={props.cx}
-                      cy={props.cy}
+                      cx={props.cx ?? 0}
+                      cy={props.cy ?? 0}
                       r={3}
                       fill={color}
                       stroke={color}

--- a/frontend/src/hooks/useTechnicalIndicators.ts
+++ b/frontend/src/hooks/useTechnicalIndicators.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { technicalIndicatorService, type TechnicalIndicatorFilters, type ActiveSignalsFilters, type CalculateIndicatorsRequest } from '../services/technicalIndicatorService'
+import { technicalIndicatorService, type TechnicalIndicatorFilters, type ActiveSignalsFilters, type CalculateIndicatorsRequest, type TechnicalIndicatorHistory } from '../services/technicalIndicatorService'
 
 export const TECHNICAL_INDICATORS_KEYS = {
   all: ['technical-indicators'] as const,
@@ -31,7 +31,7 @@ export function useLatestIndicators(symbol: string, filters?: TechnicalIndicator
 /**
  * Hook para obtener el historial de indicadores técnicos
  */
-export function useIndicatorHistory(symbol: string, filters?: { indicator?: string; days?: number; limit?: number }) {
+export function useIndicatorHistory(symbol: string, filters?: TechnicalIndicatorHistory) {
   return useQuery({
     queryKey: TECHNICAL_INDICATORS_KEYS.history(symbol, filters || {}),
     queryFn: () => technicalIndicatorService.getIndicatorHistory(symbol, filters),
@@ -113,7 +113,7 @@ export function useCalculateIndicators() {
   return useMutation({
     mutationFn: (request: CalculateIndicatorsRequest) => 
       technicalIndicatorService.calculateIndicators(request),
-    onSuccess: (data, variables) => {
+    onSuccess: (_data, variables) => {
       // Invalidar caché relacionado
       if (variables.symbol) {
         queryClient.invalidateQueries({ 


### PR DESCRIPTION
## Summary
- tighten the technical indicator chart dot renderer typing to satisfy Recharts expectations and remove the unused default React import
- align the indicator history hook with the service contract and silence the unused mutation payload in the technical indicators module

## Testing
- npm run lint
- npm run type-check *(fails: existing BreakEven, InstrumentsManager, Watchlist, notificationService issues)*

------
https://chatgpt.com/codex/tasks/task_e_68d6edf562bc832799ba81b7bd49cc6e